### PR TITLE
Group certifications by issuer and year

### DIFF
--- a/certificaciones.json
+++ b/certificaciones.json
@@ -13,7 +13,8 @@
   {
     "category": "Marketing y Negocios",
     "items": [
-      "Marketing Digital, Product Marketing (Platzi, 2024)",
+      "Marketing Digital (Platzi, 2024)",
+      "Product Marketing (Platzi, 2024)",
       "Fundamentos de Mkt Digital (Coursera, 2025)",
       "Marketing 360 (Eidos Global, 2025)"
     ]
@@ -21,8 +22,10 @@
   {
     "category": "Habilidades Personales",
     "items": [
-      "Curso de Oratoria, Habilidades Blandas (Platzi, 2024-2025)",
-      "Entender Emociones I (Coursera, 2025), Entender Emociones II (Platzi, 2024)",
+      "Curso de Oratoria (Platzi, 2024-2025)",
+      "Habilidades Blandas (Platzi, 2024-2025)",
+      "Entender Emociones I (Coursera, 2025)",
+      "Entender Emociones II (Platzi, 2024)",
       "Gestión del Tiempo (Platzi, 2024)"
     ]
   },
@@ -30,7 +33,8 @@
     "category": "Ofimática y Datos",
     "items": [
       "Excel (Básico, Intermedio, Avanzado, Macros) (Platzi, 2024)",
-      "Excel 2010, Word 2010 (SENA, 2014-2015)",
+      "Excel 2010 (SENA, 2014-2015)",
+      "Word 2010 (SENA, 2014-2015)",
       "PowerPoint y Word para empresas (Platzi, 2024)"
     ]
   },


### PR DESCRIPTION
## Summary
- split certifications with multiple names
- remove bullet styling in sidebar lists
- group certifications by entity/year in JS for concise display

## Testing
- `python -m json.tool profile.json`
- `python -m json.tool experiencia.json`
- `python -m json.tool formacion.json`
- `python -m json.tool certificaciones.json`

------
https://chatgpt.com/codex/tasks/task_e_684bd61809d48326abd5dc6aa7daf82b