### PR TITLE
Improve PDF export layout

### DIFF
--- a/scripts/pdf.js
+++ b/scripts/pdf.js
@@ -17,7 +17,10 @@ export function setupPdfExport() {
     function exportPdf(option) {
       const container = document.querySelector('.max-w-6xl');
       const bulletLists = container.querySelectorAll('#experienceList ul');
-      bulletLists.forEach(ul => ul.classList.add('no-bullets'));
+      bulletLists.forEach(ul => {
+        ul.classList.add('no-bullets');
+        ul.querySelectorAll('li').forEach(li => li.classList.add('no-bullets'));
+      });
       html2canvas(container, { scale: 2, useCORS: true }).then(canvas => {
         const imgData = canvas.toDataURL('image/png');
       let pdfWidth, pdfHeight;
@@ -37,7 +40,10 @@ export function setupPdfExport() {
       }
         doc.addImage(imgData, 'PNG', 0, 0, imgWidth, imgHeight);
         doc.save('cv.pdf');
-        bulletLists.forEach(ul => ul.classList.remove('no-bullets'));
+        bulletLists.forEach(ul => {
+          ul.classList.remove('no-bullets');
+          ul.querySelectorAll('li').forEach(li => li.classList.remove('no-bullets'));
+        });
       });
   }
 }

--- a/scripts/pdf.js
+++ b/scripts/pdf.js
@@ -14,10 +14,12 @@ export function setupPdfExport() {
     });
   });
 
-  function exportPdf(option) {
-    const container = document.querySelector('.max-w-6xl');
-    html2canvas(container, { scale: 2, useCORS: true }).then(canvas => {
-      const imgData = canvas.toDataURL('image/png');
+    function exportPdf(option) {
+      const container = document.querySelector('.max-w-6xl');
+      const bulletLists = container.querySelectorAll('#experienceList ul');
+      bulletLists.forEach(ul => ul.classList.add('no-bullets'));
+      html2canvas(container, { scale: 2, useCORS: true }).then(canvas => {
+        const imgData = canvas.toDataURL('image/png');
       let pdfWidth, pdfHeight;
       if (option === 'letter') {
         pdfWidth = 612;
@@ -33,8 +35,9 @@ export function setupPdfExport() {
         imgHeight = pdfHeight;
         imgWidth = canvas.width * pdfHeight / canvas.height;
       }
-      doc.addImage(imgData, 'PNG', 0, 0, imgWidth, imgHeight);
-      doc.save('cv.pdf');
-    });
+        doc.addImage(imgData, 'PNG', 0, 0, imgWidth, imgHeight);
+        doc.save('cv.pdf');
+        bulletLists.forEach(ul => ul.classList.remove('no-bullets'));
+      });
   }
 }

--- a/styles/base.css
+++ b/styles/base.css
@@ -12,7 +12,13 @@ body {
 .border-edge-green { border-color: #42C89A; }
 .icon-cyan { color: #00A4EF; }
 
-.no-bullets {
-    list-style: none;
+.no-bullets,
+.no-bullets li {
+    list-style: none !important;
     padding-left: 0;
+    margin-left: 0;
+}
+
+.no-bullets li::marker {
+    content: '' !important;
 }

--- a/styles/base.css
+++ b/styles/base.css
@@ -11,3 +11,8 @@ body {
 .text-edge-cyan { color: #00A4EF; }
 .border-edge-green { border-color: #42C89A; }
 .icon-cyan { color: #00A4EF; }
+
+.no-bullets {
+    list-style: none;
+    padding-left: 0;
+}


### PR DESCRIPTION
## Summary
- hide bullet points during PDF export to avoid extra spacing
- add reusable `.no-bullets` utility class

## Testing
- `python -m json.tool profile.json`
- `python -m json.tool experiencia.json`
- `python -m json.tool formacion.json`
- `python -m json.tool certificaciones.json`


------
https://chatgpt.com/codex/tasks/task_e_684bdbecf74c8326a7e866fb1b544ee9