### PR TITLE
Remove bullets and bold certification headers

### DIFF
--- a/scripts/dataLoader.js
+++ b/scripts/dataLoader.js
@@ -80,7 +80,7 @@ export async function loadData() {
     div.innerHTML = `
           <h4 class="font-semibold text-md text-gray-800">${item.role}</h4>
           <p class="text-xs text-gray-500 mb-1">${item.company} | ${item.period}</p>
-          <ul class="list-disc list-inside text-gray-600 text-sm space-y-1">
+          <ul class="text-gray-600 text-sm space-y-1">
             ${item.details.map(d => `<li>${d}</li>`).join('')}
           </ul>
     `;
@@ -125,7 +125,7 @@ export async function loadData() {
     div.innerHTML = `
           <h4 class="font-bold text-gray-700 mb-2 uppercase">${cat.category}</h4>
           ${sorted.map(g => `
-            <p class="font-medium text-gray-700">${g.entity} (${g.year})</p>
+            <p class="font-bold text-gray-700">${g.entity} (${g.year})</p>
             <ul class="space-y-1 text-gray-600 ml-4">
               ${g.courses.map(c => `<li>${c}</li>`).join('')}
             </ul>

--- a/scripts/pdf.js
+++ b/scripts/pdf.js
@@ -16,11 +16,6 @@ export function setupPdfExport() {
 
     function exportPdf(option) {
       const container = document.querySelector('.max-w-6xl');
-      const bulletLists = container.querySelectorAll('#experienceList ul');
-      bulletLists.forEach(ul => {
-        ul.classList.add('no-bullets');
-        ul.querySelectorAll('li').forEach(li => li.classList.add('no-bullets'));
-      });
       html2canvas(container, { scale: 2, useCORS: true }).then(canvas => {
         const imgData = canvas.toDataURL('image/png');
       let pdfWidth, pdfHeight;
@@ -40,10 +35,6 @@ export function setupPdfExport() {
       }
         doc.addImage(imgData, 'PNG', 0, 0, imgWidth, imgHeight);
         doc.save('cv.pdf');
-        bulletLists.forEach(ul => {
-          ul.classList.remove('no-bullets');
-          ul.querySelectorAll('li').forEach(li => li.classList.remove('no-bullets'));
-        });
       });
   }
 }

--- a/styles/base.css
+++ b/styles/base.css
@@ -12,13 +12,9 @@ body {
 .border-edge-green { border-color: #42C89A; }
 .icon-cyan { color: #00A4EF; }
 
-.no-bullets,
-.no-bullets li {
-    list-style: none !important;
+
+ul {
+    list-style: none;
     padding-left: 0;
     margin-left: 0;
-}
-
-.no-bullets li::marker {
-    content: '' !important;
 }


### PR DESCRIPTION
## Summary
- drop unused `.no-bullets` style and make all lists unstyled
- remove bullet list handling in PDF export
- show experience items without bullet classes
- highlight certification entity and year in bold

## Testing
- `python -m json.tool profile.json`
- `python -m json.tool experiencia.json`
- `python -m json.tool formacion.json`
- `python -m json.tool certificaciones.json`


------
https://chatgpt.com/codex/tasks/task_e_684bdfd8cafc8326aeec4cbc1babb01b